### PR TITLE
feature: score without clef and or time signature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ import VexFlow from 'vexflow'
 const VF = VexFlow.Flow
 const { Formatter, Renderer, Stave, StaveNote } = VF
 
-const clefAndTimeWidth = 60
+const clefWidth = 30;
+const timeWidth = 30;
 
 export function Score({
   staves = [],
@@ -27,6 +28,7 @@ export function Score({
     renderer.resize(width, height)
     const context = renderer.getContext()
     context.setFont('Arial', 10, '').setBackgroundFillStyle('#eed')
+    const clefAndTimeWidth = (clef ? clefWidth : 0) + (timeSignature ? timeWidth : 0);
     const staveWidth = (width - clefAndTimeWidth) / staves.length
 
     let currX = 0
@@ -34,7 +36,8 @@ export function Score({
       const stave = new Stave(currX, 0, staveWidth)
       if (i === 0) {
         stave.setWidth(staveWidth + clefAndTimeWidth)
-        stave.addClef(clef).addTimeSignature(timeSignature)
+        clef && stave.addClef(clef);
+        timeSignature && stave.addTimeSignature(timeSignature);
       }
       currX += stave.getWidth()
       stave.setContext(context).draw()


### PR DESCRIPTION
Hey there nice react wrapper around vexflow!
I don't know if you are still interested in this lib or accept PRs..
While playing around with it, I added the possibility to define scores without clef and or time signature. This allows displaying multiple staff columns without always showing clef/time like this:

```jsx
<Score
  width={600}
  staves={[
    ['a3', 'd4', 'e4', 'd4'],
    ['a4', 'd4', ['e4', 8], ['f4', 8], 'd4'],
    ['a4', 'a4', 'b4', 'a4'],
    ['d4', 'e4', ['g4', 2]]
  ]}
/>
<Score
  width={600}
  timeSignature=""
  clef=""
  staves={[
    ['a3', 'd4', 'e4', 'd4'],
    ['a4', 'd4', ['e4', 8], ['f4', 8], 'd4'],
    ['a4', 'a4', 'b4', 'a4'],
    ['d4', 'e4', ['g4', 2]]
  ]}
/>
```

I think the changes are pretty straightforward and should not break anything.
Greetings, Felix